### PR TITLE
Misfist/bugfix wp_localize_script

### DIFF
--- a/chatwoot-plugin.php
+++ b/chatwoot-plugin.php
@@ -56,6 +56,11 @@ function chatwoot_load() {
   $chatwoot_launcher_text = get_option('chatwootLauncherText');
 
 	// Localize our variables for the Javascript embed code.
+  /**
+   * 3rd parameter must be an array
+   * 
+   * @since 0.2.1
+   */
 	wp_localize_script( 'chatwoot-client', 'chatwoot_token', array( $chatwoot_token ) );
 	wp_localize_script( 'chatwoot-client', 'chatwoot_url', array( $chatwoot_url ) );
 	wp_localize_script( 'chatwoot-client', 'chatwoot_widget_locale', array( $chatwoot_widget_locale ) );

--- a/chatwoot-plugin.php
+++ b/chatwoot-plugin.php
@@ -47,13 +47,13 @@ add_action( 'wp_enqueue_scripts', 'chatwoot_load' );
  */
 function chatwoot_load() {
 
-  // Get our site options for site url and token.
-  $chatwoot_url = get_option('chatwootSiteURL');
-  $chatwoot_token = get_option('chatwootSiteToken');
-  $chatwoot_widget_locale = get_option('chatwootWidgetLocale');
-  $chatwoot_widget_type = get_option('chatwootWidgetType');
-  $chatwoot_widget_position = get_option('chatwootWidgetPosition');
-  $chatwoot_launcher_text = get_option('chatwootLauncherText');
+	// Get our site options for site url and token.
+	$chatwoot_url             = get_option( 'chatwootSiteURL' );
+	$chatwoot_token           = get_option( 'chatwootSiteToken' );
+	$chatwoot_widget_locale   = get_option( 'chatwootWidge tLocale' );
+	$chatwoot_widget_type     = get_option( 'chatwootWidgetType' );
+	$chatwoot_widget_position = get_option( 'chatwootWidgetPosition' );
+	$chatwoot_launcher_text   = get_option( 'chatwootLauncherText' );
 
 	// Localize our variables for the Javascript embed code.
   /**
@@ -69,7 +69,7 @@ function chatwoot_load() {
 	wp_localize_script( 'chatwoot-client', 'chatwoot_widget_position', array( $chatwoot_widget_position ) );
 }
 
-add_action('admin_menu', 'chatwoot_setup_menu');
+add_action( 'admin_menu', 'chatwoot_setup_menu' );
 /**
  * Set up Settings options page.
  *

--- a/chatwoot-plugin.php
+++ b/chatwoot-plugin.php
@@ -55,13 +55,13 @@ function chatwoot_load() {
   $chatwoot_widget_position = get_option('chatwootWidgetPosition');
   $chatwoot_launcher_text = get_option('chatwootLauncherText');
 
-  // Localize our variables for the Javascript embed code.
-  wp_localize_script('chatwoot-client', 'chatwoot_token', $chatwoot_token);
-  wp_localize_script('chatwoot-client', 'chatwoot_url', $chatwoot_url);
-  wp_localize_script('chatwoot-client', 'chatwoot_widget_locale', $chatwoot_widget_locale);
-  wp_localize_script('chatwoot-client', 'chatwoot_widget_type', $chatwoot_widget_type);
-  wp_localize_script('chatwoot-client', 'chatwoot_launcher_text', $chatwoot_launcher_text);
-  wp_localize_script('chatwoot-client', 'chatwoot_widget_position', $chatwoot_widget_position);
+	// Localize our variables for the Javascript embed code.
+	wp_localize_script( 'chatwoot-client', 'chatwoot_token', array( $chatwoot_token ) );
+	wp_localize_script( 'chatwoot-client', 'chatwoot_url', array( $chatwoot_url ) );
+	wp_localize_script( 'chatwoot-client', 'chatwoot_widget_locale', array( $chatwoot_widget_locale ) );
+	wp_localize_script( 'chatwoot-client', 'chatwoot_widget_type', array( $chatwoot_widget_type ) );
+	wp_localize_script( 'chatwoot-client', 'chatwoot_launcher_text', array( $chatwoot_launcher_text ) );
+	wp_localize_script( 'chatwoot-client', 'chatwoot_widget_position', array( $chatwoot_widget_position ) );
 }
 
 add_action('admin_menu', 'chatwoot_setup_menu');

--- a/chatwoot-plugin.php
+++ b/chatwoot-plugin.php
@@ -39,6 +39,8 @@ add_action( 'wp_enqueue_scripts', 'chatwoot_load' );
 /**
  * Initialize embed code options.
  *
+ * @link https://developer.wordpress.org/reference/functions/wp_localize_script/
+ *
  * @since 0.1.0
  *
  * @return {void}.


### PR DESCRIPTION
Update `wp_localize_script` usage to fix WordPress error:

```
Notice: Function WP_Scripts::localize was called incorrectly. The $l10n parameter must be an array. To pass arbitrary data to scripts, use the wp_add_inline_script() function instead. Please see Debugging in WordPress for more information. (This message was added in version 5.7.0.) in /var/www/html/wp-includes/functions.php on line 5835
```

- [Add link to WordPress function](https://github.com/misfist/wp-chatwoot/commit/bfac481cd02bd770a6d7f1ac073c70a4a1403e78)
   - See https://developer.wordpress.org/reference/functions/wp_localize_script/
- [Change 3rd param to array](https://github.com/misfist/wp-chatwoot/commit/48cd4b18cc54322ccb7b0161ef093603166199ea)
- [Add comment about change](https://github.com/misfist/wp-chatwoot/commit/083f01fee6b670f2278efe0d8e824b6eb771a4bb)
- [WordPress coding standards formatting](https://github.com/misfist/wp-chatwoot/commit/b744e0749b0f552f26f9b8724bc5abd36009aee7)
   - See https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#space-usage